### PR TITLE
ci: make linting stricter to be closer to what build requires

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Install dependencies
         run: bun install
       - name: Run lint
-        run: bun run eslint:fix
+        run: bun run lint

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev --turbo",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "next lint --max-warnings 0",
     "pkg": "bun install && npm i --package-lock-only",
     "eslint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "eslint:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",


### PR DESCRIPTION
this should prevent cases where the linting passes but the build then fails because of linting issues